### PR TITLE
 Modified so that pod can be acquired normally with modern Perldoc.jp

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Encode'              => '0';
 requires 'HTTP::Tiny'          => '0';
+requires 'IO::Socket::SSL'     => '0';
 requires 'Path::Tiny'          => '0.044';
 requires 'Pod::Perldoc'        => '3.23';
 requires 'Pod::Text'           => '3.13';

--- a/lib/Pod/PerldocJp.pm
+++ b/lib/Pod/PerldocJp.pm
@@ -48,7 +48,7 @@ sub grand_search_init {
   if (not $self->opt_F and ($self->opt_J or ($pages->[0] && $pages->[0] =~ /^https?:/))) {
     my $ua  = HTTP::Tiny->new(agent => "Pod-PerldocJp/$VERSION");
 
-    my $api_url = $ENV{PERLDOCJP_SERVER} || 'http://perldoc.charsbar.org/api/pod';
+    my $api_url = $ENV{PERLDOCJP_SERVER} || 'https://perldoc.jp' || 'http://perldoc.charsbar.org/api/pod';
     $api_url =~ s|/+$||;
 
     foreach my $page (@$pages) {


### PR DESCRIPTION
## Problem

When I used this command, I  got an error like this.

```sh
$perldocjp -f print
Error stat on '/var/folders/_m/06f7270x6qnf592klj8x4d_c0000gn/T/.perldocjp/perlfunc.pod': No such file or directory at /Users/anatofuz/.sandbox/local/lib/perl5/Pod/PerldocJp.pm line 78.
```

There were several reasons why this problem happened.

##  Unable to access the API server.

Now, Pod::PerldocJP is try to access `PERLDOCJP_SERVER` environment variable or http://perldoc.charsbar.org/api/pod.

https://github.com/charsbar/pod-perldocjp/blob/bd2ffe4e01bd6d3983bfd0a75929c042ebda01fb/lib/Pod/PerldocJp.pm#L51

Usually `PERLDOCJP_SERVER` is not set, so access to perldoc.charsbar.org.
But now this website has an error.

So I modified to access the current perldoc.jp
https://github.com/charsbar/pod-perldocjp/commit/f442cbb3acdbaebac1b6917b29f3dc8ca908e595

Therefore, I wrote IO::Socket::SSL in cpanfile because it communicates with using SSL(at https://perldoc.jp).

https://github.com/charsbar/pod-perldocjp/commit/9717c5e834c5289094ffdb1409c0e1c521be2c42

##  HTML is fetched instead of pod

The current perldoc.jp cannot download pod files unless you access xxx.pod.pod instead of xxx.pod.
Therefore, it was modified to download the actual pod file after redirecting.


https://github.com/charsbar/pod-perldocjp/commit/78040a83ba3a6a4c241c7160ff072b03fdfa2549

Thanks!
